### PR TITLE
Fix fatal error regarding exception handling

### DIFF
--- a/src/main/java/com/ittovative/otpservice/exception/GeneralExceptionHandler.java
+++ b/src/main/java/com/ittovative/otpservice/exception/GeneralExceptionHandler.java
@@ -8,14 +8,14 @@ import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-@ControllerAdvice
+@RestControllerAdvice
 public class GeneralExceptionHandler {
     /**
      * Handle validation exceptions response entity.
@@ -24,7 +24,7 @@ public class GeneralExceptionHandler {
      * @return the response entity
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public APIResponse<Map<String, String>> handleValidationExceptions(
+    APIResponse<Map<String, String>> handleValidationExceptions(
             MethodArgumentNotValidException exception) {
 
         Map<String, String> errors = new HashMap<>();


### PR DESCRIPTION
Removed @ControllerAdvice and used @RestControllerAdvice instead to be able to return ``APIResponse`` . The error was caused by not using @ResponseBody which basically wrapped our object into an HttpResponse   

https://stackoverflow.com/questions/43124391/restcontrolleradvice-vs-controlleradvice

For future usage
Always use @ControllerAdvice with @ResponseBody when using a web service or just use @RestControllerAdvice and it will wrap the returned objects 